### PR TITLE
Hotfix/scss

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -117,5 +117,5 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
-  config.assets.css_compressor = Escompress::Compressor.new(loader: :css)
+  config.assets.css_compressor = nil
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -117,4 +117,5 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  config.assets.css_compressor = Escompress::Compressor.new(loader: :css)
 end


### PR DESCRIPTION
Added line `config.assets.css_compressor = nil` in `config/environments/production.rb`

Sass-rails gem is slightly outdated. Modern CSS allows for a RGB gradient syntax without commas, however Sass does not follow this convention. Utilizing the sass-rails gem to compress css was causing errors when it encountered Tailwind's gradients.