### PR TITLE
Added validation to email update

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -2,8 +2,9 @@
 
 class Account < ApplicationRecord
   belongs_to :status
-  validates :FirstName, :LastName, :Email, :status_id, presence: true
-  validates :Email, uniqueness: true, presence: true
+  validates :FirstName, :LastName, :status_id, presence: true
+  validates :Email, uniqueness: true, presence: true, format: { with: /\@tamu.edu/,
+		message: "Only TAMU Email addresses allowed" }
   validates :UIN, uniqueness: true, presence: true, length: { is: 9 }
   validates :PhoneNumber, uniqueness: true, presence: true, length: { is: 10 }
 end


### PR DESCRIPTION
With this push, I have successfully validated all updated email addresses. Now when a user tries to update their email address, they must use one with a TAMU domain.

**Current user tries to update their email address with a non TAMU email.**
![image](https://user-images.githubusercontent.com/107882353/203218970-5d4a877c-bed2-4166-b7ce-0eb66c160314.png)

**New email address is of type TAMU and is successful**
![image](https://user-images.githubusercontent.com/107882353/203219201-e2988532-5a27-4636-8c9f-575d9fe39e21.png)

