### PR TITLE
bugfix - removed edit button on account dashboard for points

### DIFF
--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -90,7 +90,6 @@
 								<td><%= point.event.Date.strftime("%b %-d") %></td>
 								<td><%= point.Points %></td>
                                 <% if @current_user.status_id == 1 or @current_user.status_id == 2 %>
-								    <td><%= link_to 'Edit', edit_point_path(point), class:'btn btn-ghost btn-sm' %></td>
 								    <td><%= link_to 'Delete', point, method: :delete, data: { confirm: 'Are you sure?' }, class:'btn btn-error btn-sm' %></td>
                                 <% end %>
 							</tr>


### PR DESCRIPTION
Edit button no longer appears under points section of account dashboard
<img width="547" alt="image" src="https://user-images.githubusercontent.com/107882353/203680923-c2c73a6c-878a-4d6a-8bb9-a0239afb7c3f.png">
