### PR TITLE
ROT-62

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -77,8 +77,10 @@
 					<thead>
 						<tr>
 							<th>Account</th>
+								<% if @current_user.status_id == 1 or @current_user.status_id == 2 %>
 							<th>Email</th>
 							<th>Phone Number</th>
+                  <% end %>
 							<th>Needs a Ride</th>
 							<th colspan="6"></th>
 						</tr>
@@ -88,8 +90,10 @@
 							<tr>
 								<% next if signup.event_id != @event.id %>
 								<td><%= signup.account.FirstName.capitalize() + " " + signup.account.LastName.capitalize() %></td>
+								<% if @current_user.status_id == 1 or @current_user.status_id == 2 %>
 								<td><%= signup.account.Email %></td>
 								<td><%= signup.account.PhoneNumber %></td>
+                  <% end %>
 								<td><%= convertBool(signup.Pickup) %></td>
 								<% if signup.account_id == @account.id %>
 									<% @hasSignedUp = true%>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,8 +12,6 @@ end
 
 # Create accounts
 Account.create!([
-  { UIN: 167421892, FirstName: 'Joe', LastName: 'Smith', PhoneNumber: 1234567890, Email: 'joe@smith.com', status_id: 2 , uuid: 'TEST_ACCOUNT_01' },
-  { UIN: 718276728, FirstName: 'Rishav', LastName: 'Dokania', PhoneNumber: 8729106896, Email: 'rishavkrd11@tamu.edu', status_id: 1, uuid: 'TEST_ACCOUNT_02' },
   { UIN: 123458729, FirstName: 'Sam', LastName: 'McDonalds', PhoneNumber: 5784297498, Email: 'sam@tamu.edu', status_id: 2, uuid:'TEST_ACCOUNT_03' },
   { UIN: 162719977, FirstName: 'John', LastName: 'Goodman', PhoneNumber: 6767982934, Email: 'john@tamu.edu', status_id: 2, uuid:'TEST_ACCOUNT_04' },
 ])


### PR DESCRIPTION
Fixed account details on the events page. Originally, anybody could view the account details for those who had signed up for a specific event. That has now been fixed.

**As an admin or officer.**
![image](https://user-images.githubusercontent.com/107882353/205111991-0ab90c1b-b585-4673-a97b-dd9460e79788.png)

**As a member.**
![image](https://user-images.githubusercontent.com/107882353/205112162-f27cb69e-f6d6-4345-ad4e-464f79c3e203.png)
